### PR TITLE
30% speed improvement in create_reachability_map

### DIFF
--- a/base_placement_plugin/src/place_base.cpp
+++ b/base_placement_plugin/src/place_base.cpp
@@ -143,6 +143,7 @@ void PlaceBase::findbase(std::vector< geometry_msgs::Pose > grasp_poses)
       // Normalization for inverse Reachability Index
 
       std::vector< int > poseCount;
+	  poseCount.reserve(baseTrnsCol.size());
       for (std::multimap< std::vector< double >, std::vector< double > >::iterator it = baseTrnsCol.begin(); it != baseTrnsCol.end();
            ++it)
       {

--- a/map_creator/include/map_creator/kinematics.h
+++ b/map_creator/include/map_creator/kinematics.h
@@ -32,11 +32,11 @@ public:
   float NORM(float a, float b, float c, float d);
   void getPoseFromFK(const std::vector< double > joint_values, std::vector< double >& pose);
 
-  bool isIKSuccess(std::vector< double > pose, std::vector< double >& joints, int& numOfSolns);
+  bool isIKSuccess(const std::vector<double> &pose, std::vector<double> &joints, int& numOfSolns);
 
   const std::string getRobotName();
 
-  bool isIkSuccesswithTransformedBase(const geometry_msgs::Pose base_pose, const geometry_msgs::Pose grasp_pose,
+  bool isIkSuccesswithTransformedBase(const geometry_msgs::Pose& base_pose, const geometry_msgs::Pose& grasp_pose,
                                       int& numOfSolns);
 };
 }

--- a/map_creator/include/map_creator/sphere_discretization.h
+++ b/map_creator/include/map_creator/sphere_discretization.h
@@ -29,19 +29,19 @@ public:
   ~SphereDiscretization(){}
 
   //! Generating a sphere octree by insertRay
-  octomap::OcTree* generateSphereTree(octomap::point3d origin, float radius, float resolution);
+  octomap::OcTree* generateSphereTree(const octomap::point3d& origin, float radius, float resolution);
 
   //! Generating a sphere octree by creating poincloud and pushing to octree
-  octomap::OcTree* generateSphereTree2(octomap::point3d origin, float radius, float resolution);
+  octomap::OcTree* generateSphereTree2(const octomap::point3d& origin, float radius, float resolution);
 
   //! Generating a box octree
-  octomap::OcTree* generateBoxTree(octomap::point3d origin, float diameter, float resolution);
+  octomap::OcTree* generateBoxTree(const octomap::point3d& origin, float diameter, float resolution);
 
   //! Creating a sphere with points and return poincloud
-  octomap::Pointcloud make_sphere_points(octomap::point3d origin, double r);
+  octomap::Pointcloud make_sphere_points(const octomap::point3d& origin, double r);
 
   //! Creating a sphere and and create poses on the outer sphere and return vector of poses
-  std::vector< geometry_msgs::Pose > make_sphere_poses(octomap::point3d origin, double r);
+  void make_sphere_poses(const octomap::point3d &origin, double r, std::vector< geometry_msgs::Pose >& pose_Col);
 
   //! Creating random doubles
   double irand(int min, int max);
@@ -56,10 +56,10 @@ public:
   octomap::Pointcloud make_sphere_fibonacci_grid(octomap::point3d origin, double r, int sample);
 
   //! Creates sphere spiral points and returns pointcloud
-  octomap::Pointcloud make_sphere_spiral_points(octomap::point3d origin, double r, int sample);
+  octomap::Pointcloud make_sphere_spiral_points(const octomap::point3d &origin, double r, int sample);
 
   //! Creates long lat grid on a sphere
-  octomap::Pointcloud make_long_lat_grid(octomap::point3d origin, double r, int sample, int lat_num, int lon_num);
+  octomap::Pointcloud make_long_lat_grid(const octomap::point3d &origin, double r, int sample, int lat_num, int lon_num);
 
   //! Returns non-negative numbers of R8 division
   double r8_modp(double x, double y);
@@ -71,20 +71,20 @@ public:
   void convertVectorToPoint(const std::vector< double > data, octomap::point3d& point);
 
   //! Converting geometry_msgs::Pose to vector[7]
-  void convertPoseToVector(const geometry_msgs::Pose pose, std::vector< double >& data);
+  void convertPoseToVector(const geometry_msgs::Pose &pose, std::vector< double >& data);
 
   //! Converting vector[7] to geometry_msgs::Pose
-  void convertVectorToPose(const std::vector< double > data, geometry_msgs::Pose& pose);
+  void convertVectorToPose(const std::vector< double >& data, geometry_msgs::Pose& pose);
 
   //! Finding optimal pose by averaging all and returning pose
-  geometry_msgs::Pose findOptimalPose(const std::vector< geometry_msgs::Pose > poses, octomap::point3d origin);
+  geometry_msgs::Pose findOptimalPose(const std::vector< geometry_msgs::Pose >& poses, const octomap::point3d& origin);
 
   //! Creates cone by PointCloud
-  void createConeCloud(const geometry_msgs::Pose pose, const double angle, const double scale,
-                       pcl::PointCloud< pcl::PointXYZ >::Ptr cloud);
+  void createConeCloud(const geometry_msgs::Pose &pose, const double angle, const double scale,
+					   pcl::PointCloud< pcl::PointXYZ >::Ptr cloud);
 
   //! Creates point by removing orientation part of a pose
-  void poseToPoint(const geometry_msgs::Pose pose, octomap::point3d& point);
+  void poseToPoint(const geometry_msgs::Pose& pose, octomap::point3d& point);
 
   //! Defines if a point belongs to a pointcloud. First crates a hull of the poincloud and computes Area, then adds the
   //point to the pointcloud and again computes new Area. If the New Area is bigger than the previous area, the point is
@@ -92,19 +92,19 @@ public:
   bool isPointInCloud(pcl::PointCloud< pcl::PointXYZ >::Ptr cloud, octomap::point3d point);
 
   //! Finds L2 norm distance between two points
-  float distanceL2norm(const octomap::point3d p1, const octomap::point3d p2);
+  float distanceL2norm(const octomap::point3d& p1, const octomap::point3d& p2);
 
   //! Converts geometry_msgs::Pose to Eigen Vector
-  void poseToEigenVector(const geometry_msgs::Pose pose, Eigen::VectorXd& vec);
+  void poseToEigenVector(const geometry_msgs::Pose& pose, Eigen::VectorXd& vec);
 
   //! Finds optimal pose of given poses by Principal Component Optimization
-  void findOptimalPosebyPCA(const std::vector< geometry_msgs::Pose > probBasePoses, geometry_msgs::Pose& final_base_pose);
+  void findOptimalPosebyPCA(const std::vector< geometry_msgs::Pose >& probBasePoses, geometry_msgs::Pose& final_base_pose);
 
   //! Finds if two quaternions are close
-  bool areQuaternionClose(tf2::Quaternion q1, tf2::Quaternion q2);
+  bool areQuaternionClose(const tf2::Quaternion &q1, const tf2::Quaternion &q2);
 
   //! Computes the inverse signature of a quaternion
-  tf2::Quaternion inverseSignQuaternion(tf2::Quaternion q);
+  tf2::Quaternion inverseSignQuaternion(const tf2::Quaternion& q);
 
   //! Finds optimal pose of given poses by average
   void findOptimalPosebyAverage(const std::vector< geometry_msgs::Pose > probBasePoses,
@@ -112,9 +112,9 @@ public:
 
   //! Given grasp poses and multimap structure of an inverse reachability map, transforms every pose of the ir map with
   //grasp poses, and calculates nearest neighbor search to associate poses with belonging spheres.
-  void associatePose(std::multimap< std::vector< double >, std::vector< double > >& baseTrnsCol,
-                     const std::vector< geometry_msgs::Pose > grasp_poses,
-                     const std::multimap< std::vector< double >, std::vector< double > > PoseColFilter, const float resolution);
+  void associatePose(std::multimap<std::vector<double>, std::vector<double> > &baseTrnsCol,
+					 const std::vector< geometry_msgs::Pose >& grasp_poses,
+					 const std::multimap<std::vector<double>, std::vector<double> > &PoseColFilter, const float resolution);
 
   //! Compare two vectors, of length 3, for multimap search
   struct vec_comp_

--- a/map_creator/src/create_capability_map.cpp
+++ b/map_creator/src/create_capability_map.cpp
@@ -106,19 +106,20 @@ int main(int argc, char **argv)
     float radius = resolution;
 
     std::multimap< std::vector< double >, std::vector< double > > PoseCol;
-    for (int i = 0; i < newData.size(); i++)
     {
       std::vector< geometry_msgs::Pose > pose;
       std::vector< double > sphere_coord;
-      sd.convertPointToVector(newData[i], sphere_coord);
-
-      pose = sd.make_sphere_poses(newData[i], radius);
-      for (int j = 0; j < pose.size(); j++)
+      std::vector< double > point_on_sphere;
+      for (int i = 0; i < newData.size(); i++)
       {
-        std::vector< double > point_on_sphere;
-        sd.convertPoseToVector(pose[j], point_on_sphere);
+        sd.convertPointToVector(newData[i], sphere_coord);
 
-        PoseCol.insert(std::pair< std::vector< double >, std::vector< double > >(point_on_sphere, sphere_coord));
+        sd.make_sphere_poses(newData[i], radius, pose);
+        for (int j = 0; j < pose.size(); j++)
+        {
+          sd.convertPoseToVector(pose[j], point_on_sphere);
+          PoseCol.insert(std::make_pair(point_on_sphere, sphere_coord));
+        }
       }
     }
 

--- a/map_creator/src/create_inverse_reachability_map.cpp
+++ b/map_creator/src/create_inverse_reachability_map.cpp
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
     std::vector< octomap::point3d > newData;
 
     std::vector< geometry_msgs::Pose > pose;
-    pose = sd.make_sphere_poses(origin, resolution);  // calculating number of points on a sphere by discretization
+    sd.make_sphere_poses(origin, resolution, pose);  // calculating number of points on a sphere by discretization
 
     for (octomap::OcTree::leaf_iterator it = tree->begin_leafs(maxDepth), end = tree->end_leafs(); it != end; ++it)
     {

--- a/map_creator/src/create_reachability_map.cpp
+++ b/map_creator/src/create_reachability_map.cpp
@@ -189,11 +189,11 @@ int main(int argc, char **argv)
 
       for (int i = 0; i < 3; i++)
       {
-        poseAndSphere[i]=((*it->first)[i]);
+        poseAndSphere[i]=((*sphere_coord)[i]);
       }
       for (int j = 0; j < 7; j++)
       {
-        poseAndSphere[3+j]=((*it->second)[j]);
+        poseAndSphere[3+j]=((*point_on_sphere)[j]);
       }
 
       poseReach.push_back(poseAndSphere);

--- a/map_creator/src/create_reachability_map.cpp
+++ b/map_creator/src/create_reachability_map.cpp
@@ -101,6 +101,12 @@ int main(int argc, char **argv)
     octomap::OcTree *tree = sd.generateBoxTree(origin, r, resolution);
     std::vector< octomap::point3d > newData;
     ROS_INFO("Creating the box and discretizing with resolution: %f", resolution);
+    int sphere_count = 0;
+    for (octomap::OcTree::leaf_iterator it = tree->begin_leafs(maxDepth), end = tree->end_leafs(); it != end; ++it)
+    {
+      sphere_count++;
+    }
+    newData.reserve(sphere_count);
     for (octomap::OcTree::leaf_iterator it = tree->begin_leafs(maxDepth), end = tree->end_leafs(); it != end; ++it)
     {
       newData.push_back(it.getCoordinate());

--- a/map_creator/src/create_reachability_map.cpp
+++ b/map_creator/src/create_reachability_map.cpp
@@ -44,9 +44,9 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "workspace");
   ros::NodeHandle n;
-  time_t startit, finish;
-  time(&startit);
-  float resolution = 0.08;
+  ros::Time startit = ros::Time::now();
+
+  float resolution = 0.06;
   Kinematics k;
   string ext = ".h5";
   string filename =
@@ -429,8 +429,8 @@ int main(int argc, char **argv)
     H5Gclose(group_spheres);
 
     H5Fclose(file);
-    time(&finish);
-    double dif = difftime(finish, startit);
+
+	double dif = ros::Duration( ros::Time::now() - startit).toSec();
     ROS_INFO("Elasped time is %.2lf seconds.", dif);
     ROS_INFO("Completed");
     ros::spinOnce();

--- a/map_creator/src/create_reachability_map.cpp
+++ b/map_creator/src/create_reachability_map.cpp
@@ -128,14 +128,14 @@ int main(int argc, char **argv)
 
     for (int i = 0; i < newData.size(); i++)
     {
-      std::vector< geometry_msgs::Pose > pose;
+      static std::vector< geometry_msgs::Pose > pose;
       sd.convertPointToVector(newData[i], SphereCoord[i]);
 
 
-      pose = sd.make_sphere_poses(newData[i], radius);
+      sd.make_sphere_poses(newData[i], radius, pose);
       for (int j = 0; j < pose.size(); j++)
       {
-        std::vector< double > point_on_sphere;
+        static std::vector< double > point_on_sphere;
         sd.convertPoseToVector(pose[j], point_on_sphere);
 
         PoseCol.push_back( std::make_pair(point_on_sphere, &SphereCoord[i]));

--- a/map_creator/src/create_reachability_map.cpp
+++ b/map_creator/src/create_reachability_map.cpp
@@ -131,13 +131,11 @@ int main(int argc, char **argv)
       static std::vector< geometry_msgs::Pose > pose;
       sd.convertPointToVector(newData[i], SphereCoord[i]);
 
-
       sd.make_sphere_poses(newData[i], radius, pose);
       for (int j = 0; j < pose.size(); j++)
       {
         static std::vector< double > point_on_sphere;
         sd.convertPoseToVector(pose[j], point_on_sphere);
-
         PoseCol.push_back( std::make_pair(point_on_sphere, &SphereCoord[i]));
       }
     }
@@ -155,8 +153,7 @@ int main(int argc, char **argv)
 
     for (MultiVector::iterator it = PoseCol.begin(); it != PoseCol.end(); ++it)
     {
-      std::vector< double > joints;
-      joints.resize(6);
+      static std::vector< double > joints(6);
       int solns;
       if (k.isIKSuccess(it->first, joints, solns))
       {
@@ -187,17 +184,16 @@ int main(int argc, char **argv)
       float d = float(PoseColFilter.count(sphere_coord)) / (PoseCol.size() / newData.size()) * 100;
       sphereColor.insert( std::make_pair(it->first, double(d)));
 
-      // poseReach.push_back(it->second);
-      std::vector< double > poseAndSphere;
-      poseAndSphere.reserve( sphere_coord->size() + point_on_sphere->size());
+      // poseReach.push_back(it->second)
+      static std::vector< double > poseAndSphere(10);
 
-      for (int i = 0; i < sphere_coord->size(); i++)
+      for (int i = 0; i < 3; i++)
       {
-        poseAndSphere.push_back((*it->first)[i]);
+        poseAndSphere[i]=((*it->first)[i]);
       }
-      for (int j = 0; j < point_on_sphere->size(); j++)
+      for (int j = 0; j < 7; j++)
       {
-        poseAndSphere.push_back((*it->second)[j]);
+        poseAndSphere[3+j]=((*it->second)[j]);
       }
 
       poseReach.push_back(poseAndSphere);

--- a/map_creator/src/sphere_discretization.cpp
+++ b/map_creator/src/sphere_discretization.cpp
@@ -95,14 +95,13 @@ octomap::Pointcloud SphereDiscretization::make_sphere_points(const octomap::poin
 void SphereDiscretization::make_sphere_poses(const octomap::point3d& origin, double r, std::vector< geometry_msgs::Pose >& pose_Col)
 {
   const double DELTA = M_PI / 5.;
-  static boost::array<geometry_msgs::Vector3,10> position_vector;
-  static boost::array<tf2::Quaternion,10> quaternion;
+  const unsigned MAX_INDEX = (2 * 5 * 5);
+  static std::vector<geometry_msgs::Vector3> position_vector(MAX_COUNT);
+  static std::vector<tf2::Quaternion> quaternion(MAX_COUNT);
   static bool initialized = false;
-  static int MAX_INDEX = 0;
+
   if( !initialized ){
-
     initialized=true;
-
     unsigned index = 0;
     for (double phi = 0; phi < 2*M_PI; phi += DELTA)  // Azimuth [0, 2PI]
     {
@@ -120,7 +119,6 @@ void SphereDiscretization::make_sphere_poses(const octomap::point3d& origin, dou
         index++;
       }
     }
-    MAX_INDEX = index;
   }
   pose_Col.reserve( MAX_INDEX );
   pose_Col.clear();

--- a/map_creator/src/sphere_discretization.cpp
+++ b/map_creator/src/sphere_discretization.cpp
@@ -96,8 +96,8 @@ void SphereDiscretization::make_sphere_poses(const octomap::point3d& origin, dou
 {
   const double DELTA = M_PI / 5.;
   const unsigned MAX_INDEX = (2 * 5 * 5);
-  static std::vector<geometry_msgs::Vector3> position_vector(MAX_COUNT);
-  static std::vector<tf2::Quaternion> quaternion(MAX_COUNT);
+  static std::vector<geometry_msgs::Vector3> position_vector(MAX_INDEX);
+  static std::vector<tf2::Quaternion> quaternion(MAX_INDEX);
   static bool initialized = false;
 
   if( !initialized ){

--- a/map_creator/src/sphere_discretization.cpp
+++ b/map_creator/src/sphere_discretization.cpp
@@ -4,7 +4,7 @@ namespace sphere_discretization
 {
 // SphereDiscretization::SphereDiscretization(){}
 
-octomap::OcTree* SphereDiscretization::generateSphereTree(octomap::point3d origin, float radius, float resolution)
+octomap::OcTree* SphereDiscretization::generateSphereTree(const octomap::point3d& origin, float radius, float resolution)
 {
   octomap::OcTree* tree = new octomap::OcTree(resolution);
   octomap::point3d point_on_surface = origin;
@@ -26,7 +26,7 @@ octomap::OcTree* SphereDiscretization::generateSphereTree(octomap::point3d origi
   return tree;
 }
 
-octomap::OcTree* SphereDiscretization::generateSphereTree2(octomap::point3d origin, float radius, float resolution)
+octomap::OcTree* SphereDiscretization::generateSphereTree2(const octomap::point3d& origin, float radius, float resolution)
 {
   octomap::OcTree* tree = new octomap::OcTree(resolution);
   octomap::point3d point_on_surface = origin;
@@ -50,7 +50,7 @@ octomap::OcTree* SphereDiscretization::generateSphereTree2(octomap::point3d orig
   return tree;
 }
 
-octomap::OcTree* SphereDiscretization::generateBoxTree(octomap::point3d origin, float diameter, float resolution)
+octomap::OcTree* SphereDiscretization::generateBoxTree(const octomap::point3d& origin, float diameter, float resolution)
 {
   octomap::OcTree* tree = new octomap::OcTree(resolution / 2);
   octomap::Pointcloud p;
@@ -73,7 +73,7 @@ octomap::OcTree* SphereDiscretization::generateBoxTree(octomap::point3d origin, 
   return tree;
 };
 
-octomap::Pointcloud SphereDiscretization::make_sphere_points(octomap::point3d origin, double r)
+octomap::Pointcloud SphereDiscretization::make_sphere_points(const octomap::point3d& origin, double r)
 {
   octomap::Pointcloud spherePoints;
   spherePoints.reserve( 7*7*2 );
@@ -91,27 +91,41 @@ octomap::Pointcloud SphereDiscretization::make_sphere_points(octomap::point3d or
   return spherePoints;
 }
 
-std::vector< geometry_msgs::Pose > SphereDiscretization::make_sphere_poses(octomap::point3d origin, double r)
+
+void SphereDiscretization::make_sphere_poses(const octomap::point3d& origin, double r, std::vector< geometry_msgs::Pose >& pose_Col)
 {
-  std::vector< geometry_msgs::Pose > pose_Col;
   pose_Col.reserve( 5*5*2 );
+  pose_Col.clear();
+
+  const double DELTA = M_PI / 5.;
+  static boost::array<double,10> Cos;
+  static boost::array<double,10> Sin;
+  static bool initialized = false;
+  if( !initialized ){
+    for (int i=0; i< 10; i++){
+      Cos[i] = cos(i*DELTA);
+      Sin[i] = sin(i*DELTA);
+    }
+    initialized=true;
+  }
+
   geometry_msgs::Pose pose;
   // TODO Most of the robots have a roll joint as their final joint which can move 0 to 2pi. So if a pose is reachable,
   // then the discretization of roll poses are also reachable. It will increase the data, so we have to decide if we
   // have to use it. The robot whose final roll joint cannot move 0 to 2pi, we have to use it.
   // for (double rot = 0.; rot < 2*M_PI; rot += M_PI/6){
 
-  for (double phi = 0.; phi < 2 * M_PI; phi += M_PI / 5.)  // Azimuth [0, 2PI]
+  for (int phi = 0; phi < 10; phi ++)  // Azimuth [0, 2PI]
   {
-    for (double theta = 0.; theta < M_PI; theta += M_PI / 5.)  // Elevation [0, PI]
+    for (int theta = 0; theta < 5; theta ++)  // Elevation [0, PI]
     {
-      pose.position.x = r * cos(phi) * sin(theta) + origin.x();
-      pose.position.y = r * sin(phi) * sin(theta) + origin.y();
-      pose.position.z = r * cos(theta) + origin.z();
+      pose.position.x = r * Cos[phi] * Sin[theta] + origin.x();
+      pose.position.y = r * Sin[phi] * Sin[theta] + origin.y();
+      pose.position.z = r * Cos[theta] + origin.z();
       tf2::Quaternion quat;
       // tf2::Quaternion quat2;
       // quat2.setRPY(M_PI/6,0,0);
-      quat.setRPY(0, ((M_PI / 2) + theta), phi);
+      quat.setRPY(0, ((M_PI / 2) + theta*DELTA), phi);
       // quat=quat*quat2;
       quat.normalize();
       pose.orientation.x = quat.x();
@@ -121,8 +135,6 @@ std::vector< geometry_msgs::Pose > SphereDiscretization::make_sphere_poses(octom
       pose_Col.push_back(pose);
     }
   }
-  //}
-  return pose_Col;
 }
 
 double SphereDiscretization::irand(int min, int max)
@@ -224,7 +236,7 @@ double SphereDiscretization::r8_modp(double x, double y)
   return value;
 }
 
-octomap::Pointcloud SphereDiscretization::make_sphere_spiral_points(octomap::point3d origin, double r, int sample)
+octomap::Pointcloud SphereDiscretization::make_sphere_spiral_points(const octomap::point3d& origin, double r, int sample)
 {
   octomap::Pointcloud spherePoints;
   spherePoints.reserve(sample);
@@ -257,7 +269,7 @@ octomap::Pointcloud SphereDiscretization::make_sphere_spiral_points(octomap::poi
   return spherePoints;
 }
 
-octomap::Pointcloud SphereDiscretization::make_long_lat_grid(octomap::point3d origin, double r, int sample, int lat_num, int lon_num)
+octomap::Pointcloud SphereDiscretization::make_long_lat_grid(const octomap::point3d& origin, double r, int sample, int lat_num, int lon_num)
 {
   octomap::Pointcloud spherePoints;
 
@@ -292,10 +304,10 @@ octomap::Pointcloud SphereDiscretization::make_long_lat_grid(octomap::point3d or
 
 void SphereDiscretization::convertPointToVector(const octomap::point3d point, std::vector< double >& data)
 {
-  data.reserve(3);
-  data.push_back(double(point.x()));
-  data.push_back(double(point.y()));
-  data.push_back(double(point.z()));
+  data.resize(3);
+  data[0]=(double(point.x()));
+  data[1]=(double(point.y()));
+  data[2]=(double(point.z()));
 }
 
 void SphereDiscretization::convertVectorToPoint(const std::vector< double > data, octomap::point3d &point)
@@ -305,19 +317,19 @@ void SphereDiscretization::convertVectorToPoint(const std::vector< double > data
   point.z() = data[2];
 }
 
-void SphereDiscretization::convertPoseToVector(const geometry_msgs::Pose pose, std::vector< double > &data)
+void SphereDiscretization::convertPoseToVector(const geometry_msgs::Pose& pose, std::vector< double > &data)
 {
-  data.reserve(7);
-  data.push_back(double(pose.position.x));
-  data.push_back(double(pose.position.y));
-  data.push_back(double(pose.position.z));
-  data.push_back(double(pose.orientation.x));
-  data.push_back(double(pose.orientation.y));
-  data.push_back(double(pose.orientation.z));
-  data.push_back(double(pose.orientation.w));
+  data.resize(7);
+  data[0]=(double(pose.position.x));
+  data[1]=(double(pose.position.y));
+  data[2]=(double(pose.position.z));
+  data[3]=(double(pose.orientation.x));
+  data[4]=(double(pose.orientation.y));
+  data[5]=(double(pose.orientation.z));
+  data[6]=(double(pose.orientation.w));
 }
 
-void SphereDiscretization::convertVectorToPose(const std::vector< double > data, geometry_msgs::Pose &pose)
+void SphereDiscretization::convertVectorToPose(const std::vector< double >& data, geometry_msgs::Pose &pose)
 {
   pose.position.x = data[0];
   pose.position.y = data[1];
@@ -328,7 +340,7 @@ void SphereDiscretization::convertVectorToPose(const std::vector< double > data,
   pose.orientation.w = data[6];
 }
 
-geometry_msgs::Pose SphereDiscretization::findOptimalPose(const std::vector< geometry_msgs::Pose > poses, octomap::point3d origin)
+geometry_msgs::Pose SphereDiscretization::findOptimalPose(const std::vector< geometry_msgs::Pose >& poses, const octomap::point3d& origin)
 {
   geometry_msgs::Pose optiPose;
   double mydo[] = {0, 0, 0, 0, 0, 0};
@@ -356,7 +368,7 @@ geometry_msgs::Pose SphereDiscretization::findOptimalPose(const std::vector< geo
   return optiPose;
 }
 
-void SphereDiscretization::createConeCloud(const geometry_msgs::Pose pose, const double opening_angle,
+void SphereDiscretization::createConeCloud(const geometry_msgs::Pose& pose, const double opening_angle,
                                            const double scale, pcl::PointCloud< pcl::PointXYZ >::Ptr cloud)
 {
   pcl::PointCloud< pcl::PointXYZ >::Ptr new_cloud(new pcl::PointCloud< pcl::PointXYZ >);
@@ -387,7 +399,7 @@ void SphereDiscretization::createConeCloud(const geometry_msgs::Pose pose, const
   pcl::transformPointCloud(*new_cloud, *cloud, transform);
 }
 
-void SphereDiscretization::poseToPoint(const geometry_msgs::Pose pose, octomap::point3d &point)
+void SphereDiscretization::poseToPoint(const geometry_msgs::Pose& pose, octomap::point3d &point)
 {
   point.x() = pose.position.x;
   point.y() = pose.position.y;
@@ -426,21 +438,20 @@ bool SphereDiscretization::isPointInCloud(pcl::PointCloud< pcl::PointXYZ >::Ptr 
   }
 }
 
-float SphereDiscretization::distanceL2norm(const octomap::point3d p1, const octomap::point3d p2)
+float SphereDiscretization::distanceL2norm(const octomap::point3d& p1, const octomap::point3d& p2)
 {
-  float dist;
-  dist = sqrt((p1.x() - p2.x()) * (p1.x() - p2.x()) + (p1.y() - p2.y()) * (p1.y() - p2.y()) +
+  return sqrt((p1.x() - p2.x()) * (p1.x() - p2.x()) +
+              (p1.y() - p2.y()) * (p1.y() - p2.y()) +
               (p1.z() - p2.z()) * (p1.z() - p2.z()));
-  return dist;
 }
 
-void SphereDiscretization::poseToEigenVector(const geometry_msgs::Pose pose, Eigen::VectorXd& vec)
+void SphereDiscretization::poseToEigenVector(const geometry_msgs::Pose& pose, Eigen::VectorXd& vec)
 {
   vec << pose.position.x, pose.position.y, pose.position.z, pose.orientation.x, pose.orientation.y, pose.orientation.z,
       pose.orientation.w;
 }
 
-void SphereDiscretization::findOptimalPosebyPCA(const std::vector< geometry_msgs::Pose > probBasePoses,
+void SphereDiscretization::findOptimalPosebyPCA(const std::vector< geometry_msgs::Pose >& probBasePoses,
                                                 geometry_msgs::Pose& final_base_pose)
 {
   Eigen::Matrix4d M;
@@ -480,19 +491,15 @@ void SphereDiscretization::findOptimalPosebyPCA(const std::vector< geometry_msgs
   final_base_pose.orientation.w = vector[3];
 }
 
-bool SphereDiscretization::areQuaternionClose(tf2::Quaternion q1, tf2::Quaternion q2)
+bool SphereDiscretization::areQuaternionClose(const tf2::Quaternion& q1, const tf2::Quaternion& q2)
 {
   double dot = q1.dot(q2);
-  if (dot < 0)
-    return false;
-  else
-    return true;
+  return (dot >= 0);
 }
 
-tf2::Quaternion SphereDiscretization::inverseSignQuaternion(tf2::Quaternion q)
+tf2::Quaternion SphereDiscretization::inverseSignQuaternion(const tf2::Quaternion& q)
 {
-  tf2::Quaternion q_inv(-q[0], -q[1], -q[2], -q[3]);
-  return q_inv;
+  return tf2::Quaternion(-q[0], -q[1], -q[2], -q[3]);
 }
 
 void SphereDiscretization::findOptimalPosebyAverage(const std::vector< geometry_msgs::Pose > probBasePoses,
@@ -558,8 +565,8 @@ void SphereDiscretization::findOptimalPosebyAverage(const std::vector< geometry_
 }
 
 void SphereDiscretization::associatePose(std::multimap< std::vector< double >, std::vector< double > >& baseTrnsCol,
-                                         const std::vector< geometry_msgs::Pose > grasp_poses,
-                                         const std::multimap< std::vector< double >, std::vector< double > > PoseColFilter,
+                                         const std::vector< geometry_msgs::Pose >& grasp_poses,
+                                         const std::multimap< std::vector< double >, std::vector< double > >& PoseColFilter,
                                          const float resolution)
 {
   unsigned char maxDepth = 16;

--- a/map_creator/src/sphere_discretization.cpp
+++ b/map_creator/src/sphere_discretization.cpp
@@ -131,7 +131,7 @@ void SphereDiscretization::make_sphere_poses(const octomap::point3d& origin, dou
   // have to use it. The robot whose final roll joint cannot move 0 to 2pi, we have to use it.
   // for (double rot = 0.; rot < 2*M_PI; rot += M_PI/6){
 
-  for (int index = 0; index < MAX_INDEX; index++)  // Azimuth [0, 2PI]
+  for (int index = 0; index < MAX_INDEX; index++)
   {
     pose.position.x = r * position_vector[index].x + origin.x();
     pose.position.y = r * position_vector[index].y + origin.y();


### PR DESCRIPTION
Hi,

I noticed that the class SphereDiscretization does a lot of unnecessary copies.
Additionally, profiling the code with the command __perf__, I noticed that a surprisingly high number of CPU is used by the instructions __cos__ and __sin__.
I realized that methods like SphereDiscretization::make_sphere_poses call cos() and sin() over and over again with the same angle.

EDIT:

I found even more places where memory from std::vector can be recycled and the call of sin and cos can be avoided.

