### PR TITLE
Missing dependency, add metapkg, add a config for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: required 
+dist: trusty 
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+#    recipients:
+#      - jane@doe
+env:
+  matrix:
+    - USE_DEB=true  ROS_DISTRO="indigo"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="indigo"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="jade"    ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="jade"    ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+matrix:
+  allow_failures:
+    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/map_creator/package.xml
+++ b/map_creator/package.xml
@@ -43,6 +43,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>octomap</build_depend>
+  <build_depend>rviz_visual_tools</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>hdf5</build_depend>
   <build_depend>pcl_ros</build_depend>

--- a/reuleaux/CMakeLists.txt
+++ b/reuleaux/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(reuleaux)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/reuleaux/package.xml
+++ b/reuleaux/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <name>reuleaux</name>
+  <version>0.0.0</version>
+  <description>reuleaux metapackage</description>
+  <maintainer email="makhabhi@isu.edu">Abhijit Makhal</maintainer>
+  <author email="makhabhi@isu.edu">Abhijit Makhal</author>
+  <license>Apache 2.0</license>
+  <url type="website">http://wiki.ros.org/reuleaux</url>
+  <url type="repository">https://github.com/ros-industrial-consortium/reuleaux</url>
+  <url type="bugtracker">https://github.com/ros-industrial-consortium/reuleaux/issues</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>base_placement_plugin</run_depend>
+  <run_depend>map_creator</run_depend>
+  <run_depend>workspace_visualization</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
I added description to each commit message. Please take a look at them.

But maybe the most importantly, please take care of:

> If this LGTY, any admins could enable Travis (at something like https://travis-ci.org/profile/ros-industrial-consortium) by a single click to get the checking started.